### PR TITLE
add support for listing documents in schema

### DIFF
--- a/lib/resources/schemas.js
+++ b/lib/resources/schemas.js
@@ -2,6 +2,7 @@
 
 var Resource = require('../resource');
 var util = require('util');
+var querystring = require('querystring');
 
 function Schemas() {
   Schemas.super_.apply(this, arguments);
@@ -40,6 +41,34 @@ Schemas.prototype.retrieve = function(options, callback) {
     this.truevault.getOption('api_version'),
     options.vault_id,
     options.id
+  );
+
+  return this.httpsRequest({
+    path : path,
+    method : 'GET',
+    callback : callback
+  });
+
+};
+
+// Retrieves all docuements for a schema from the specified vault
+//
+// options.vault_id - vault uuid
+// options.id - schema uuid
+// callback is optional, this method returns a q promise
+Schemas.prototype.listDocuments = function(options, callback) {
+
+  var query = querystring.stringify({
+    page : options.page || 1,
+    full : options.full || false,
+    per_page : options.per_page || 100
+  });
+
+  var path = util.format("/%s/vaults/%s/schemas/%s/documents?%s",
+    this.truevault.getOption('api_version'),
+    options.vault_id,
+    options.id,
+    query
   );
 
   return this.httpsRequest({

--- a/test/schemaSpec.js
+++ b/test/schemaSpec.js
@@ -40,6 +40,25 @@ describe('schemas', function() {
 
   });
 
+  it('lists documents in schemas', function() {
+    nock('https://api.truevault.com').get('/v1/vaults/vault-uuid/schemas/schema-uuid/documents?page=1&full=false&per_page=50')
+      .reply(200, {});
+
+    schemas.listDocuments({
+      vault_id: 'vault-uuid',
+      id : 'schema-uuid',
+      per_page:50,
+      page:1,
+      full: false //true to return full documents vs uuids
+    }).then(function (value) {
+      should.exist(value);
+    }, function (err) {
+      //if we get here, this should fail
+      should.not.exist(err);
+    }).done();
+
+  });
+
   it('creates a schema', function() {
     nock('https://api.truevault.com').post('/v1/vaults/vault-uuid/schemas')
       .reply(200, {});


### PR DESCRIPTION
It was a little hard to decide whether this should go, in the documents
or schemas resource. I ended up going with schemas, because the API felt
better (schemas.listDocuments vs. documents.listInSchema). Also, the
TrueVault API exposes this under the schemas resource.
